### PR TITLE
feat: Add TransitionLink component for smooth page transitions

### DIFF
--- a/app/(next)/components/modules/EventsModule.tsx
+++ b/app/(next)/components/modules/EventsModule.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { LastEventQueryResult } from "@/sanity.types";
 
 import { DateHourFormat } from "../ui";
+import TransitionLink from "../ui/TransitionLink";
 
 type Props = {
   events: LastEventQueryResult;
@@ -18,7 +19,7 @@ export default function EventsModule({ events, title, link }: Props) {
       <h1>{title}</h1>
       {events.map((event) => (
         <li key={event.eventTitle}>
-          <Link href={`/agenda/${event.slug?.current}`}>
+          <TransitionLink href={`/agenda/${event.slug?.current}`}>
             <h2>{event.eventTitle}</h2>
             <div className="inline-block">
               <DateHourFormat
@@ -34,12 +35,12 @@ export default function EventsModule({ events, title, link }: Props) {
               )}
             </div>
             <p>{event.eventLocation}</p>
-          </Link>
+          </TransitionLink>
         </li>
       ))}
-      <Link href="/agenda" className="underline">
+      <TransitionLink href="/agenda" className="underline">
         {link}
-      </Link>
+      </TransitionLink>
     </ul>
   );
 }

--- a/app/(next)/components/modules/LinksModule.tsx
+++ b/app/(next)/components/modules/LinksModule.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import Link from "next/link";
+
+import TransitionLink from "../ui/TransitionLink";
 
 type Props = {
   item: {
@@ -13,12 +14,12 @@ export default function LinksModule({ item }: Props) {
   const link = item;
   return (
     <div className="py-[1rem]">
-      <Link
+      <TransitionLink
         href={`${link.internal?.slug || link.external}`}
         className="underline"
       >
         {link.linkLabel}
-      </Link>
+      </TransitionLink>
     </div>
   );
 }

--- a/app/(next)/components/ui/Heroes/StickyHero.tsx
+++ b/app/(next)/components/ui/Heroes/StickyHero.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 
 import { HomepageQueryResult } from "@/sanity.types";
 import TextSplitting from "../TextSplitting";
+import TransitionLink from "../TransitionLink";
 
 type Props = {
   heroes: HomepageQueryResult;
@@ -17,7 +18,7 @@ export default function StickyHero({ heroes }: Props) {
       className="no-scrollbar relative max-h-[calc(100dvh-5rem)] overflow-y-scroll"
     >
       {heroes?.hero?.map((hero) => (
-        <Link
+        <TransitionLink
           key={hero.title!}
           href={
             hero.cta?.ctaLink?._type === "pages"
@@ -75,7 +76,7 @@ export default function StickyHero({ heroes }: Props) {
               </div>
             </div>
           )}
-        </Link>
+        </TransitionLink>
       ))}
     </div>
   );

--- a/app/(next)/components/ui/TransitionLink.tsx
+++ b/app/(next)/components/ui/TransitionLink.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { animatePageOut } from "../../utils/animations";
+import Link from "next/link";
 
 type Props = {
   key?: string;
@@ -19,15 +20,15 @@ export default function TransitionLink({
   const router = useRouter();
   const pathname = usePathname();
 
-  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
     if (pathname != href) {
       animatePageOut(href, router);
     }
   };
   return (
-    <button key={key} onClick={handleClick} className={className}>
+    <Link key={key} href={href} onClick={handleClick} className={className}>
       {children}
-    </button>
+    </Link>
   );
 }


### PR DESCRIPTION
- Add TransitionLink component to create smooth transitions between pages
- Update EventsModule, LinksModule, and StickyHero components to use TransitionLink instead of Link